### PR TITLE
include polyfill for `ClipboardItem`

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@visx/responsive": "^3.10.2",
     "@visx/scale": "^3.5.0",
     "class-variance-authority": "^0.7.0",
+    "clipboard-polyfill": "^4.1.0",
     "clsx": "^2.0.0",
     "d3": "^7.9.0",
     "drizzle-orm": "^0.28.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.0
+      clipboard-polyfill:
+        specifier: ^4.1.0
+        version: 4.1.0
       clsx:
         specifier: ^2.0.0
         version: 2.0.0
@@ -1439,6 +1442,9 @@ packages:
 
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
+  clipboard-polyfill@4.1.0:
+    resolution: {integrity: sha512-ksMESxI9ermQxE3hOC4DGwfjmrAxuHVtwQoJMsy06ylpaY4ybISb6y21yJ17xg9EO9ZVWvzSLIkJRlO93E8Gng==}
 
   clsx@2.0.0:
     resolution: {integrity: sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==}
@@ -4290,6 +4296,8 @@ snapshots:
       timers-ext: 0.1.7
 
   client-only@0.0.1: {}
+
+  clipboard-polyfill@4.1.0: {}
 
   clsx@2.0.0: {}
 

--- a/src/components/ui/tweet-box.tsx
+++ b/src/components/ui/tweet-box.tsx
@@ -11,6 +11,8 @@ import { Textarea } from "./textarea";
 import { useQuery } from "@tanstack/react-query";
 import { ClipboardIcon, ClipboardCheckIcon } from "lucide-react";
 
+import { ClipboardItem } from "clipboard-polyfill";
+
 export function TweetBox(props: { src: string; text: string }) {
   const [copySuccess, setCopySuccess] = useState<boolean>(false);
   const { data } = useQuery(["copy-image"], async () => {


### PR DESCRIPTION
On Firefox, only Firefox Nightly and Firefox Beta support `ClipboardItem` while Firefox Stable and Firefox LTS don't.

The PR introduces a polyfill for `ClipboardItem`.