### PR TITLE
fix wrong condition order introduced in #39

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,6 @@
 import { type ClassValue, clsx } from "clsx"
 import { twMerge } from "tailwind-merge"
-import { User } from "../server/db/schema";
+import { type User } from "../server/db/schema";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
@@ -19,13 +19,16 @@ export function getRatioText(input: {
   const { tweets, commits, displayName } = input;
 
   // edge cases
+  if (tweets === 0 && commits === 0) {
+    return `${displayName} is a mysterious creature`;
+  }
   if (tweets === 0) {
     return `${displayName} is locked into coding`;
-  } else if (commits === 0) {
+  }
+  if (commits === 0) {
     return `${displayName} is a Twitter addict`;
-  } else if (tweets === 0 && commits === 0) {
-    return `${displayName} is a mysterious creature`;
-  } else if (tweets === commits) {
+  }
+  if (tweets === commits) {
     return `${displayName}'s life is perfectly balanced, as all things should be`;
   }
 


### PR DESCRIPTION
cc @rudrodip

There is a bug in #39.

https://github.com/RhysSullivan/shiptalkers/blob/f66af67da025efcbb5a687dfe233bd342614a9ac/src/lib/utils.ts#L22-L28

**Line 27 here is never reachable**, because if either `tweets` or `commits` is `0`, they will early return, and Line 26's condition will never be met.